### PR TITLE
2023.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "browser"]
 	path = browser
 	url = https://github.com/mozilla-mobile/firefox-android.git
-  branch = fenix-v115.2.1
+  branch = fenix-v117.0.1

--- a/assets/bootstrap.sh
+++ b/assets/bootstrap.sh
@@ -3,7 +3,7 @@ set -x
 set -e
 
 EXT_DIR="app/src/main/assets/extensions/ghostery"
-DOWNLOAD_URL="https://github.com/ghostery/ghostery-extension/releases/download/v10.1.4/ghostery-firefox-10.1.4-ff52d31.zip"
+DOWNLOAD_URL="https://github.com/ghostery/ghostery-extension/releases/download/v10.1.4.2/ghostery-firefox-10.1.4-d32a709.zip"
 rm -rf "$EXT_DIR"
 mkdir -p "$EXT_DIR"
 curl -L -o ghostery.zip "$DOWNLOAD_URL"

--- a/assets/bootstrap.sh
+++ b/assets/bootstrap.sh
@@ -3,7 +3,7 @@ set -x
 set -e
 
 EXT_DIR="app/src/main/assets/extensions/ghostery"
-DOWNLOAD_URL="https://github.com/ghostery/ghostery-extension/releases/download/v8.11.1/ghostery-dawn-v8.11.1.xpi"
+DOWNLOAD_URL="https://github.com/ghostery/ghostery-extension/releases/download/v10.1.4/ghostery-firefox-10.1.4-ff52d31.zip"
 rm -rf "$EXT_DIR"
 mkdir -p "$EXT_DIR"
 curl -L -o ghostery.zip "$DOWNLOAD_URL"

--- a/assets/bootstrap.sh
+++ b/assets/bootstrap.sh
@@ -3,7 +3,7 @@ set -x
 set -e
 
 EXT_DIR="app/src/main/assets/extensions/ghostery"
-DOWNLOAD_URL="https://github.com/ghostery/ghostery-extension/releases/download/v10.1.4.3/ghostery-firefox-10.1.4.zip"
+DOWNLOAD_URL="https://github.com/ghostery/ghostery-extension/releases/download/v10.1.4.4/ghostery-firefox-10.1.4.zip"
 rm -rf "$EXT_DIR"
 mkdir -p "$EXT_DIR"
 curl -L -o ghostery.zip "$DOWNLOAD_URL"

--- a/assets/bootstrap.sh
+++ b/assets/bootstrap.sh
@@ -3,7 +3,7 @@ set -x
 set -e
 
 EXT_DIR="app/src/main/assets/extensions/ghostery"
-DOWNLOAD_URL="https://github.com/ghostery/ghostery-extension/releases/download/v10.1.4.2/ghostery-firefox-10.1.4-d32a709.zip"
+DOWNLOAD_URL="https://github.com/ghostery/ghostery-extension/releases/download/v10.1.4.3/ghostery-firefox-10.1.4.zip"
 rm -rf "$EXT_DIR"
 mkdir -p "$EXT_DIR"
 curl -L -o ghostery.zip "$DOWNLOAD_URL"
@@ -11,7 +11,7 @@ unzip -o ghostery.zip -d "$EXT_DIR"
 rm ghostery.zip
 
 SEARCH_EXT_DIR="app/src/main/assets/extensions/ghostery-search"
-SEARCH_DOWNLOAD_URL="https://github.com/ghostery/ghostery-search-extension/releases/download/v1.1.0/ghostery_private_search-1.1.0.zip"
+SEARCH_DOWNLOAD_URL="https://github.com/ghostery/ghostery-search-extension/releases/download/v1.1.1/ghostery_private_search-1.1.1.zip"
 rm -rf "$SEARCH_EXT_DIR"
 mkdir -p "$SEARCH_EXT_DIR"
 curl -L -o ghostery_search.zip "$SEARCH_DOWNLOAD_URL"

--- a/config.sh
+++ b/config.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-export FENIX_TAG=fenix-v115.2.1
+export FENIX_TAG=fenix-v117.0.1

--- a/patches/0001-Ghostery-Logo-Added.patch
+++ b/patches/0001-Ghostery-Logo-Added.patch
@@ -13,14 +13,14 @@ diff --git a/fenix/app/build.gradle b/fenix/app/build.gradle
 index fe39a12064..50dab8d5e8 100644
 --- a/fenix/app/build.gradle
 +++ b/fenix/app/build.gradle
-@@ -33,7 +33,7 @@ android {
+@@ -32,7 +32,7 @@ android {
      }
- 
+
      defaultConfig {
 -        applicationId "org.mozilla"
 +        applicationId "com.ghostery.android"
-         minSdkVersion Config.minSdkVersion
-         targetSdkVersion Config.targetSdkVersion
+         minSdkVersion config.minSdkVersion
+         targetSdkVersion config.targetSdkVersion
          versionCode 1
 @@ -110,7 +110,7 @@ android {
          debug {
@@ -53,7 +53,7 @@ index fe39a12064..50dab8d5e8 100644
 +            ]
 +        }
      }
- 
+
      buildFeatures {
 diff --git a/fenix/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml b/fenix/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
 index de34ac4858..9e9d6e7325 100644
@@ -81,6 +81,6 @@ index de34ac4858..9e9d6e7325 100644
      <foreground android:drawable="@drawable/ic_launcher_foreground"/>
      <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
  </adaptive-icon>
--- 
+--
 2.39.2 (Apple Git-143)
 

--- a/patches/0008-Ghostery-Private-Search-as-default-search-engine.patch
+++ b/patches/0008-Ghostery-Private-Search-as-default-search-engine.patch
@@ -119,16 +119,16 @@ index b620c393fe..027a0418b0 100644
 +                })
          }
      }
- 
-@@ -258,7 +267,7 @@ class Core(
+
+@@ -270,7 +277,7 @@ class Core(
                  RegionMiddleware(context, locationService),
                  SearchMiddleware(
-                     context,
+                     context = context,
 -                    additionalBundledSearchEngineIds = listOf("reddit", "youtube"),
 +                    additionalBundledSearchEngineIds = listOf("ghostery", "brave", "reddit", "youtube"),
                      migration = SearchMigration(context),
+                     searchExtraParams = searchExtraParams,
                  ),
-                 RecordingDevicesMiddleware(context, context.components.notificationsDelegate),
--- 
+--
 2.39.2 (Apple Git-143)
 

--- a/patches/0014-Removig-What-s-new-from-the-Home-menu.patch
+++ b/patches/0014-Removig-What-s-new-from-the-Home-menu.patch
@@ -11,10 +11,10 @@ diff --git a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt b/fenix/
 index 1588f03a84..cdfeb884f8 100644
 --- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
 +++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
-@@ -98,12 +98,6 @@ class HomeMenu(
+@@ -100,12 +100,6 @@ class HomeMenu(
          }
      }
- 
+
 -    private fun syncSignInMenuItem(): BrowserMenuItem {
 -        return BrowserMenuSignIn(primaryTextColor) {
 -            onItemTapped.invoke(Item.SyncAccount(accountManager.accountState))
@@ -24,10 +24,10 @@ index 1588f03a84..cdfeb884f8 100644
      val desktopItem = BrowserMenuImageSwitch(
          imageResource = R.drawable.ic_desktop,
          label = context.getString(R.string.browser_menu_desktop_site),
-@@ -140,14 +134,6 @@ class HomeMenu(
+@@ -142,14 +136,6 @@ class HomeMenu(
              onItemTapped.invoke(Item.Downloads)
          }
- 
+
 -        val extensionsItem = BrowserMenuImageText(
 -            context.getString(R.string.browser_menu_add_ons),
 -            R.drawable.ic_addons_extensions,
@@ -39,10 +39,10 @@ index 1588f03a84..cdfeb884f8 100644
          val manageAccountAndDevicesItem = SimpleBrowserMenuItem(
              context.getString(R.string.browser_menu_manage_account_and_devices),
              textColorResource = primaryTextColor,
-@@ -155,26 +141,6 @@ class HomeMenu(
+@@ -157,26 +143,6 @@ class HomeMenu(
              onItemTapped.invoke(Item.ManageAccountAndDevices)
          }
- 
+
 -        val whatsNewItem = BrowserMenuHighlightableItem(
 -            context.getString(R.string.browser_menu_whats_new),
 -            R.drawable.ic_whats_new,
@@ -57,7 +57,7 @@ index 1588f03a84..cdfeb884f8 100644
 -
 -        val helpItem = BrowserMenuImageText(
 -            context.getString(R.string.browser_menu_help),
--            R.drawable.mozac_ic_help,
+-            R.drawable.mozac_ic_help_circle_24,
 -            primaryTextColor,
 -        ) {
 -            onItemTapped.invoke(Item.Help)
@@ -66,10 +66,10 @@ index 1588f03a84..cdfeb884f8 100644
          val customizeHomeItem = BrowserMenuImageText(
              context.getString(R.string.browser_menu_customize_home_1),
              R.drawable.ic_customize,
-@@ -193,30 +159,14 @@ class HomeMenu(
+@@ -196,36 +162,19 @@ class HomeMenu(
              onItemTapped.invoke(Item.Settings)
          }
- 
+
 -        // Only query account manager if it has been initialized.
 -        // We don't want to cause its initialization just for this check.
 -        val accountAuthItem =
@@ -81,12 +81,18 @@ index 1588f03a84..cdfeb884f8 100644
 -                null
 -            }
 -
+         // Since syncSignIn & accountAuth items take us to the same place -> we won't show them in the same time
+         // We will show syncSignIn item when the accountAuth item:
+         //    1. is not needed or
+         //    2. it is needed, but the account manager is not available yet
+-        val syncSignInMenuItem = if (accountAuthItem == null) syncSignInMenuItem() else null
+
          val menuItems = listOfNotNull(
              bookmarksItem,
              historyItem,
              downloadsItem,
 -            extensionsItem,
--            syncSignInMenuItem(),
+-            syncSignInMenuItem,
 -            accountAuthItem,
              if (Config.channel.isMozillaOnline) manageAccountAndDevicesItem else null,
              BrowserMenuDivider(),
@@ -97,6 +103,6 @@ index 1588f03a84..cdfeb884f8 100644
              customizeHomeItem,
              settingsItem,
              if (settings.shouldDeleteBrowsingDataOnQuit) quitItem else null,
--- 
+--
 2.39.2 (Apple Git-143)
 

--- a/patches/0020-Removing-Collections-again.patch
+++ b/patches/0020-Removing-Collections-again.patch
@@ -17,21 +17,21 @@ diff --git a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/Defaul
 index 421e306002..43ec5b4c51 100644
 --- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
 +++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
-@@ -218,10 +218,6 @@ open class DefaultToolbarMenu(
+@@ -222,10 +222,6 @@ open class DefaultToolbarMenu(
          onItemTapped.invoke(ToolbarMenu.Item.Downloads)
      }
- 
+
 -    private val extensionsItem = WebExtensionPlaceholderMenuItem(
 -        id = WebExtensionPlaceholderMenuItem.MAIN_EXTENSIONS_MENU_ID,
 -    )
 -
      private val findInPageItem = BrowserMenuImageText(
          label = context.getString(R.string.browser_menu_find_in_page),
-         imageResource = R.drawable.mozac_ic_search,
-@@ -293,14 +289,6 @@ open class DefaultToolbarMenu(
+         imageResource = R.drawable.mozac_ic_search_24,
+@@ -297,14 +293,6 @@ open class DefaultToolbarMenu(
          },
      )
- 
+
 -    private val saveToCollectionItem = BrowserMenuImageText(
 -        label = context.getString(R.string.browser_menu_save_to_collection_2),
 -        imageResource = R.drawable.ic_tab_collection,
@@ -40,13 +40,13 @@ index 421e306002..43ec5b4c51 100644
 -        onItemTapped.invoke(ToolbarMenu.Item.SaveToCollection)
 -    }
 -
-     @VisibleForTesting
-     internal val settingsItem = BrowserMenuHighlightableItem(
-         label = context.getString(R.string.browser_menu_settings),
-@@ -350,14 +338,6 @@ open class DefaultToolbarMenu(
+     private val printPageItem = BrowserMenuImageText(
+         label = context.getString(R.string.menu_print),
+         imageResource = R.drawable.ic_print,
+@@ -362,14 +350,6 @@ open class DefaultToolbarMenu(
          onItemTapped.invoke(ToolbarMenu.Item.Quit)
      }
- 
+
 -    private fun syncMenuItem(): BrowserMenuItem {
 -        return BrowserMenuSignIn(primaryTextColor()) {
 -            onItemTapped.invoke(
@@ -58,7 +58,7 @@ index 421e306002..43ec5b4c51 100644
      @VisibleForTesting(otherwise = PRIVATE)
      val coreMenuItems by lazy {
          val menuItems =
-@@ -368,8 +348,6 @@ open class DefaultToolbarMenu(
+@@ -380,8 +360,6 @@ open class DefaultToolbarMenu(
                  bookmarksItem,
                  historyItem,
                  downloadsItem,
@@ -67,14 +67,14 @@ index 421e306002..43ec5b4c51 100644
                  BrowserMenuDivider(),
                  findInPageItem,
                  desktopSiteItem,
-@@ -380,7 +358,6 @@ open class DefaultToolbarMenu(
+@@ -392,7 +370,6 @@ open class DefaultToolbarMenu(
                  addToHomeScreenItem.apply { visible = ::canAddToHomescreen },
                  installToHomescreen.apply { visible = ::canInstall },
-                 addRemoveTopSitesItem,
+                 if (shouldShowTopSites) addRemoveTopSitesItem else null,
 -                saveToCollectionItem,
+                 if (FeatureFlags.print && FxNimbus.features.print.value().browserPrintEnabled) printPageItem else null,
                  BrowserMenuDivider(),
                  settingsItem,
-                 if (shouldDeleteDataOnQuit) deleteDataOnQuit else null,
 diff --git a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
 index 4dd98bfd57..91b7473b06 100644
 --- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -82,7 +82,7 @@ index 4dd98bfd57..91b7473b06 100644
 @@ -99,23 +99,6 @@ sealed class AdapterItem(@LayoutRes val viewType: Int) {
      object PrivateBrowsingDescription : AdapterItem(PrivateBrowsingDescriptionViewHolder.LAYOUT_ID)
      object NoCollectionsMessage : AdapterItem(NoCollectionsMessageViewHolder.LAYOUT_ID)
- 
+
 -    object CollectionHeader : AdapterItem(CollectionHeaderViewHolder.LAYOUT_ID)
 -    data class CollectionItem(
 -        val collection: TabCollection,
@@ -119,7 +119,7 @@ index 2f50a9494b..728208237d 100644
 --- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
 +++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
 @@ -28,7 +28,8 @@ import org.mozilla.fenix.utils.Settings
- 
+
  // This method got a little complex with the addition of the tab tray feature flag
  // When we remove the tabs from the home screen this will get much simpler again.
 -@Suppress("ComplexMethod", "LongParameterList")
@@ -131,7 +131,7 @@ index 2f50a9494b..728208237d 100644
 @@ -79,14 +80,6 @@ internal fun normalModeAdapterItems(
          items.add(AdapterItem.RecentVisitsItems)
      }
- 
+
 -    if (collections.isEmpty()) {
 -        if (showCollectionsPlaceholder) {
 -            items.add(AdapterItem.NoCollectionsMessage)
@@ -146,7 +146,7 @@ index 2f50a9494b..728208237d 100644
 @@ -107,23 +100,6 @@ internal fun normalModeAdapterItems(
      return items
  }
- 
+
 -private fun showCollections(
 -    collections: List<TabCollection>,
 -    expandedCollections: Set<Long>,
@@ -165,7 +165,7 @@ index 2f50a9494b..728208237d 100644
 -}
 -
  private fun privateModeAdapterItems() = listOf(AdapterItem.PrivateBrowsingDescription)
- 
+
  private fun AppState.toAdapterList(settings: Settings): List<AdapterItem> = when (mode) {
 diff --git a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
 index f15acf5997..c310ebcdca 100644
@@ -183,12 +183,14 @@ diff --git a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/Selectio
 index da2ee01c80..5796659bbc 100644
 --- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
 +++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
-@@ -89,10 +89,6 @@ class SelectionBannerBinding(
+@@ -89,12 +89,6 @@ class SelectionBannerBinding(
              interactor.onShareSelectedTabs()
          }
- 
+
 -        tabsTrayMultiselectItemsBinding.collectMultiSelect.setOnClickListener {
--            interactor.onAddSelectedTabsToCollectionClicked()
+-            if (store.state.mode.selectedTabs.isNotEmpty()) {
+-                interactor.onAddSelectedTabsToCollectionClicked()
+-            }
 -        }
 -
          binding.exitMultiSelect.setOnClickListener {
@@ -214,7 +216,7 @@ index 67d2eee9e2..01b3348b22 100644
 @@ -9,19 +9,6 @@
      android:layout_height="wrap_content"
      tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
- 
+
 -    <ImageButton
 -        android:id="@+id/collect_multi_select"
 -        android:layout_width="48dp"
@@ -231,6 +233,6 @@ index 67d2eee9e2..01b3348b22 100644
      <ImageButton
          android:id="@+id/share_multi_select"
          android:layout_width="48dp"
--- 
+--
 2.39.2 (Apple Git-143)
 

--- a/patches/0024-Ghostery-splashscreen.patch
+++ b/patches/0024-Ghostery-splashscreen.patch
@@ -4,95 +4,51 @@ Date: Wed, 15 Jul 2020 16:11:33 +0200
 Subject: Ghostery splashscreen
 
 ---
- fenix/app/build.gradle                                    | 1 +
- fenix/app/src/main/AndroidManifest.xml                    | 1 +
- fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt | 3 +++
- fenix/app/src/main/res/values/styles.xml                  | 6 ++++++
- fenix/buildSrc/src/main/java/FenixDependencies.kt         | 2 ++
- 5 files changed, 13 insertions(+)
+ fenix/app/src/main/res/values-v24/styles.xml     | 1 +
+ fenix/app/src/main/res/values-v27/styles.xml     | 1 +
+ fenix/app/src/main/res/values/styles.xml         | 3 +++
+ 3 files changed, 13 insertions(+)
 
-diff --git a/fenix/app/build.gradle b/fenix/app/build.gradle
-index cd18be708b..992e5ee619 100644
---- a/fenix/app/build.gradle
-+++ b/fenix/app/build.gradle
-@@ -625,6 +625,7 @@ dependencies {
-     implementation FenixDependencies.androidx_lifecycle_viewmodel
-     implementation FenixDependencies.androidx_core
-     implementation FenixDependencies.androidx_core_ktx
-+    implementation FenixDependencies.androidx_core_splashscreen
-     implementation FenixDependencies.androidx_transition
-     implementation FenixDependencies.androidx_work_ktx
-     implementation FenixDependencies.androidx_datastore
-diff --git a/fenix/app/src/main/AndroidManifest.xml b/fenix/app/src/main/AndroidManifest.xml
-index a9d41ec477..9b3557f7fc 100644
---- a/fenix/app/src/main/AndroidManifest.xml
-+++ b/fenix/app/src/main/AndroidManifest.xml
-@@ -101,6 +101,7 @@
-             android:name=".HomeActivity"
-             android:exported="true"
-             android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|layoutDirection|smallestScreenSize|screenLayout"
-+            android:theme="@style/Theme.App.Starting"
-             android:launchMode="singleTask"
-             android:resizeableActivity="true"
-             android:supportsPictureInPicture="true"
-diff --git a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
-index 5d1724eebb..17c5a51fea 100644
---- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
-+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
-@@ -33,6 +33,7 @@ import androidx.annotation.VisibleForTesting.Companion.PROTECTED
- import androidx.appcompat.app.ActionBar
- import androidx.appcompat.widget.Toolbar
- import androidx.core.app.NotificationManagerCompat
-+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
- import androidx.lifecycle.lifecycleScope
- import androidx.navigation.NavDestination
- import androidx.navigation.NavDirections
-@@ -253,6 +254,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
- 
-         components.publicSuffixList.prefetch()
- 
-+        installSplashScreen()
-+
-         // Changing a language on the Language screen restarts the activity, but the activity keeps
-         // the old layout direction. We have to update the direction manually.
-         window.decorView.layoutDirection = TextUtils.getLayoutDirectionFromLocale(Locale.getDefault())
+diff --git a/fenix/app/src/main/res/values-v24/styles.xml b/fenix/app/src/main/res/values-v24/styles.xml
+index 8418254bc1..8c0fc0337f 100644
+--- a/fenix/app/src/main/res/values-v24/styles.xml
++++ b/fenix/app/src/main/res/values-v24/styles.xml
+@@ -4,6 +4,6 @@
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+ <resources>
+     <style name="SplashScreen" parent="SplashScreenThemeBase">
+-        <item name="windowSplashScreenAnimatedIcon">@drawable/animated_splash_screen</item>
++        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+     </style>
+ </resources>
+diff --git a/fenix/app/src/main/res/values-v27/styles.xml b/fenix/app/src/main/res/values-v27/styles.xml
+index 4e0eddedc9..13595fe937 100644
+--- a/fenix/app/src/main/res/values-v27/styles.xml
++++ b/fenix/app/src/main/res/values-v27/styles.xml
+@@ -28,7 +28,7 @@
+     </style>
+
+     <style name="SplashScreen" parent="SplashScreenThemeBase">
+-        <item name="windowSplashScreenAnimatedIcon">@drawable/animated_splash_screen</item>
++        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+         <!-- Splash screen is animated to maximum 12 seconds -->
+         <item name="windowSplashScreenAnimationDuration">12000</item>
+         <item name="android:windowLayoutInDisplayCutoutMode">default</item>
 diff --git a/fenix/app/src/main/res/values/styles.xml b/fenix/app/src/main/res/values/styles.xml
-index 19eaa6d166..cafcb06a48 100644
+index 0c4fe1bb35..fc3c284623 100644
 --- a/fenix/app/src/main/res/values/styles.xml
 +++ b/fenix/app/src/main/res/values/styles.xml
-@@ -130,6 +130,12 @@
-         <item name="tabCounterTintColor">?attr/textPrimary</item>
-     </style>
- 
-+    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+@@ -7,8 +7,8 @@
+     <style name="SplashScreen" parent="SplashScreenThemeBase"/>
+
+     <style name="SplashScreenThemeBase" parent="Theme.SplashScreen">
+-        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_screen</item>
+-        <item name="windowSplashScreenBackground">@color/fx_mobile_layer_color_1</item>
 +        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
 +        <item name="windowSplashScreenBackground">#202225</item>
-+        <item name="postSplashScreenTheme">@style/NormalTheme</item>
-+    </style>
-+
-     <!-- A theme derived from the normal activity theme, but to look and behave like a dialog -->
-     <style name="DialogActivityTheme" parent="NormalTheme">
-         <item name="android:windowElevation">16dp</item>
-diff --git a/fenix/buildSrc/src/main/java/FenixDependencies.kt b/fenix/buildSrc/src/main/java/FenixDependencies.kt
-index f142f33a9a..f4a5b7a954 100644
---- a/fenix/buildSrc/src/main/java/FenixDependencies.kt
-+++ b/fenix/buildSrc/src/main/java/FenixDependencies.kt
-@@ -41,6 +41,7 @@ object FenixVersions {
-     const val androidx_lifecycle = "2.6.1"
-     const val androidx_fragment = "1.5.7"
-     const val androidx_navigation = "2.5.3"
-+    const val androidx_splash_screen = "1.0.1"
-     const val androidx_recyclerview = "1.3.0"
-     const val androidx_core = "1.10.1"
-     const val androidx_paging = "3.1.1"
-@@ -95,6 +96,7 @@ object FenixDependencies {
-     const val androidx_annotation = "androidx.annotation:annotation:${FenixVersions.androidx_annotation}"
-     const val androidx_benchmark_junit4 = "androidx.benchmark:benchmark-junit4:${FenixVersions.androidx_benchmark}"
-     const val androidx_benchmark_macro_junit4 = "androidx.benchmark:benchmark-macro-junit4:${FenixVersions.androidx_benchmark}"
-+    const val androidx_core_splashscreen = "androidx.core:core-splashscreen:${FenixVersions.androidx_splash_screen}"
-     const val androidx_profileinstaller = "androidx.profileinstaller:profileinstaller:${FenixVersions.androidx_profileinstaller}"
-     const val androidx_biometric = "androidx.biometric:biometric:${FenixVersions.androidx_biometric}"
-     const val androidx_fragment = "androidx.fragment:fragment-ktx:${FenixVersions.androidx_fragment}"
--- 
+         <item name="postSplashScreenTheme">@style/NormalTheme</item>
+     </style>
+
+--
 2.39.2 (Apple Git-143)
 

--- a/patches/0028-Remove-addons-from-menu.patch
+++ b/patches/0028-Remove-addons-from-menu.patch
@@ -8,7 +8,7 @@ Subject: Remove addons from menu
  1 file changed, 4 insertions(+), 12 deletions(-)
 
 diff --git a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
-index 43ec5b4c51..3fbd1e31db 100644
+index 799a55ea58..94b8d6f416 100644
 --- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
 +++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
 @@ -14,6 +14,7 @@ import androidx.lifecycle.lifecycleScope
@@ -19,10 +19,11 @@ index 43ec5b4c51..3fbd1e31db 100644
  import mozilla.components.browser.menu.BrowserMenuHighlight
  import mozilla.components.browser.menu.BrowserMenuItem
  import mozilla.components.browser.menu.WebExtensionBrowserMenuBuilder
-@@ -76,18 +77,9 @@ open class DefaultToolbarMenu(
+@@ -79,19 +80,9 @@ open class DefaultToolbarMenu(
          get() = store.state.selectedTab
- 
+
      override val menuBuilder by lazy {
+-        FxNimbus.features.print.recordExposure()
 -        WebExtensionBrowserMenuBuilder(
 -            items = coreMenuItems,
 -            endOfMenuAlwaysVisible = shouldUseBottomToolbar,
@@ -40,7 +41,7 @@ index 43ec5b4c51..3fbd1e31db 100644
 +            endOfMenuAlwaysVisible = shouldUseBottomToolbar
          )
      }
- 
--- 
+
+--
 2.39.2 (Apple Git-143)
 

--- a/patches/0033-Fixing-null-version-name-in-About.patch
+++ b/patches/0033-Fixing-null-version-name-in-About.patch
@@ -6,16 +6,16 @@ Subject: Fixing null version name in About
 ---
  fenix/app/build.gradle                                        | 2 +-
  .../java/org/mozilla/fenix/settings/about/AboutFragment.kt    | 2 +-
- fenix/buildSrc/src/main/java/Config.kt                        | 4 ++--
+ fenix/buildSrc/src/main/java/ConfigPlugin.kt                        | 4 ++--
  3 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/fenix/app/build.gradle b/fenix/app/build.gradle
 index d813edaed2..e653f675a8 100644
 --- a/fenix/app/build.gradle
 +++ b/fenix/app/build.gradle
-@@ -37,7 +37,7 @@ android {
-         minSdkVersion Config.minSdkVersion
-         targetSdkVersion Config.targetSdkVersion
+@@ -36,7 +36,7 @@ android {
+         minSdkVersion config.minSdkVersion
+         targetSdkVersion config.targetSdkVersion
          versionCode 1
 -        versionName Config.generateDebugVersionName()
 +        versionName Config.generateDebugVersionName(project)
@@ -27,7 +27,7 @@ index f60dfc579b..60bfab2e04 100644
 --- a/fenix/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
 +++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
 @@ -108,7 +108,7 @@ class AboutFragment : Fragment(), AboutPageListener {
- 
+
              String.format(
                  "%s (Build #%s)%s\n%s: %s\n%s: %s",
 -                packageInfo.versionName,
@@ -35,13 +35,13 @@ index f60dfc579b..60bfab2e04 100644
                  versionCode,
                  maybeFenixGitHash,
                  maybeGecko,
-diff --git a/fenix/buildSrc/src/main/java/Config.kt b/fenix/buildSrc/src/main/java/Config.kt
-index 6f0e2ba50b..2af098d2d0 100644
---- a/fenix/buildSrc/src/main/java/Config.kt
-+++ b/fenix/buildSrc/src/main/java/Config.kt
-@@ -17,13 +17,13 @@ object Config {
-     const val targetSdkVersion = 33
- 
+diff --git a/android-components/plugins/config/src/main/java/ConfigPlugin.kt b/android-components/plugins/config/src/main/java/ConfigPlugin.kt
+index 03740f36db..4d161267d1 100644
+--- a/android-components/plugins/config/src/main/java/ConfigPlugin.kt
++++ b/android-components/plugins/config/src/main/java/ConfigPlugin.kt
+@@ -19,13 +19,13 @@ class ConfigPlugin : Plugin<Settings> {
+ object Config {
+
      @JvmStatic
 -    private fun generateDebugVersionName(): String {
 +    private fun generateDebugVersionName(project: Project): String {
@@ -53,8 +53,8 @@ index 6f0e2ba50b..2af098d2d0 100644
 -        return SimpleDateFormat("1.0.yyww", Locale.US).format(today)
 +        return if (project.hasProperty("versionName")) project.property("versionName") as String else SimpleDateFormat("1.0.yyww", Locale.US).format(today)
      }
- 
+
      @JvmStatic
--- 
+--
 2.39.2 (Apple Git-143)
 

--- a/patches/0034-Disable-wallpapers.patch
+++ b/patches/0034-Disable-wallpapers.patch
@@ -12,14 +12,17 @@ diff --git a/fenix/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFrag
 index 5c5f0ecbf2..f7a74c3e30 100644
 --- a/fenix/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
 +++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
-@@ -165,15 +165,6 @@ class HomeSettingsFragment : PreferenceFragmentCompat() {
+@@ -166,18 +166,6 @@ class HomeSettingsFragment : PreferenceFragmentCompat() {
          val openingScreenAfterFourHours =
              requirePreference<RadioButtonPreference>(R.string.pref_key_start_on_home_after_four_hours)
- 
+
 -        requirePreference<Preference>(R.string.pref_key_wallpapers).apply {
 -            setOnPreferenceClickListener {
--                view?.findNavController()?.navigate(
--                    HomeSettingsFragmentDirections.actionHomeSettingsFragmentToWallpaperSettingsFragment(),
+-                view?.findNavController()?.navigateWithBreadcrumb(
+-                    directions = HomeSettingsFragmentDirections.actionHomeSettingsFragmentToWallpaperSettingsFragment(),
+-                    navigateFrom = "HomeSettingsFragment",
+-                    navigateTo = "ActionHomeSettingsFragmentToWallpaperSettingsFragment",
+-                    crashReporter = context.components.analytics.crashReporter,
 -                )
 -                true
 -            }
@@ -35,7 +38,7 @@ index 35d97891d5..4dc3d9502b 100644
 @@ -38,10 +38,6 @@
          android:key="@string/pref_key_pocket_sponsored_stories"
          android:title="@string/customize_toggle_pocket_sponsored" />
- 
+
 -    <androidx.preference.Preference
 -        android:key="@string/pref_key_wallpapers"
 -        android:title="@string/customize_wallpapers" />
@@ -43,6 +46,6 @@ index 35d97891d5..4dc3d9502b 100644
      <androidx.preference.PreferenceCategory
          android:layout="@layout/preference_cat_style"
          android:title="@string/preferences_opening_screen"
--- 
+--
 2.39.2 (Apple Git-143)
 

--- a/patches/0035-Force-Ghostery-onboarding.patch
+++ b/patches/0035-Force-Ghostery-onboarding.patch
@@ -11,8 +11,8 @@ diff --git a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt b/fe
 index bf1577f055..3b37e6b2f3 100644
 --- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
 +++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
-@@ -39,6 +39,7 @@ import kotlinx.coroutines.MainScope
- import kotlinx.coroutines.delay
+@@ -40,6 +40,7 @@ import kotlinx.coroutines.delay
+ import kotlinx.coroutines.flow.distinctUntilChanged
  import kotlinx.coroutines.flow.map
  import kotlinx.coroutines.launch
 +import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
@@ -22,7 +22,7 @@ index bf1577f055..3b37e6b2f3 100644
 @@ -115,6 +116,8 @@ import org.mozilla.fenix.wallpapers.Wallpaper
  import java.lang.ref.WeakReference
  import kotlin.math.min
- 
+
 +var onboardingShownOnce = false
 +val onboardingPattern = """moz-extension://[^/]+/app/templates/onboarding\.html.*""".toRegex()
  @Suppress("TooManyFunctions", "LargeClass")
@@ -31,7 +31,7 @@ index bf1577f055..3b37e6b2f3 100644
 @@ -509,6 +512,25 @@ class HomeFragment : Fragment() {
          observeSearchEngineNameChanges()
          observeWallpaperUpdates()
- 
+
 +        // This is an hack to force the browser to display the extension on-boarding on start-up
 +        consumeFlow(store) { flow ->
 +            flow.map { state -> state.findCustomTabOrSelectedTab()?.content?.url }
@@ -54,6 +54,6 @@ index bf1577f055..3b37e6b2f3 100644
          homeMenuView = HomeMenuView(
              view = view,
              context = view.context,
--- 
+--
 2.39.2 (Apple Git-143)
 

--- a/patches/0035-Force-Ghostery-onboarding.patch
+++ b/patches/0035-Force-Ghostery-onboarding.patch
@@ -19,12 +19,12 @@ index bf1577f055..3b37e6b2f3 100644
  import mozilla.components.browser.state.selector.findTab
  import mozilla.components.browser.state.selector.normalTabs
  import mozilla.components.browser.state.selector.privateTabs
-@@ -115,6 +116,8 @@ import org.mozilla.fenix.wallpapers.Wallpaper
+@@ -117,6 +118,8 @@ import org.mozilla.fenix.wallpapers.Wallpaper
  import java.lang.ref.WeakReference
  import kotlin.math.min
 
 +var onboardingShownOnce = false
-+val onboardingPattern = """moz-extension://[^/]+/app/templates/onboarding\.html.*""".toRegex()
++val onboardingPattern = """moz-extension://[^/]+/pages/onboarding/index.html.*""".toRegex()
  @Suppress("TooManyFunctions", "LargeClass")
  class HomeFragment : Fragment() {
      private val args by navArgs<HomeFragmentArgs>()
@@ -35,7 +35,7 @@ index bf1577f055..3b37e6b2f3 100644
 +        // This is an hack to force the browser to display the extension on-boarding on start-up
 +        consumeFlow(store) { flow ->
 +            flow.map { state -> state.findCustomTabOrSelectedTab()?.content?.url }
-+                .ifChanged()
++                .distinctUntilChanged()
 +                .collect { url ->
 +                    val navController = findNavController()
 +                    if (


### PR DESCRIPTION
This is a huge change to Ghostery Private Browser for Android as it ship a new generation of Ghostery Tracker & Ad Blocker - v10.
It also updates browser with Firefox 117 codebase.

TODO Issues:
- [x] [Bottom menu is cut in the half](https://github.com/ghostery/user-agent-android/pull/41#issuecomment-1717429516)
- [ ] [Google Play Store v8 screenshots](https://github.com/ghostery/user-agent-android/pull/41#issuecomment-1717626335)
- [x] ["Software Licenses" opens a tab with a Ghostery settings screenshot](https://github.com/ghostery/user-agent-android/pull/41#issuecomment-1717656356)
- [ ] [Trackers Count is not showing number of blocked trackers](https://github.com/ghostery/user-agent-android/pull/41#issuecomment-1717675825)
- [ ] [Missing or outdated token](https://github.com/ghostery/user-agent-android/pull/41#issuecomment-1719093844)
- [x] [Tracker Prevention hides Tracker wheel ](https://github.com/ghostery/user-agent-android/pull/41#issuecomment-1719798437)
- [x] ["Become a Contributor" opens two new tabs.](https://github.com/ghostery/user-agent-android/pull/41#issuecomment-1719854223)
- [x] [WhoTracks.me Wheel is always visible](https://github.com/ghostery/user-agent-android/pull/41#issuecomment-1719881198)